### PR TITLE
Feature/login-0.2.1

### DIFF
--- a/src/components/common/ToolTip/ToolTip.tsx
+++ b/src/components/common/ToolTip/ToolTip.tsx
@@ -1,7 +1,7 @@
 import styled, { css } from "styled-components";
 
 const TooltipWrapper = styled.div<{
-  $direction: string;
+  $direction: "left" | "right" | "bottom" | "top";
   $clicked?: boolean;
   $tooltip: string;
   $options: "focus" | "hover" | "all";

--- a/src/components/common/ToolTip/ToolTip.tsx
+++ b/src/components/common/ToolTip/ToolTip.tsx
@@ -4,6 +4,7 @@ const TooltipWrapper = styled.div<{
   $direction: string;
   $clicked?: boolean;
   $tooltip: string;
+  $options: "focus" | "hover" | "all";
 }>`
   position: relative;
   z-index: 2;
@@ -33,8 +34,7 @@ const TooltipWrapper = styled.div<{
       }
     }}
     white-space: nowrap;
-    /* transition: all 0.2s ease; */
-    font-size: 20px;
+    font-size: 1.2rem;
   }
 
   &:before {
@@ -43,7 +43,7 @@ const TooltipWrapper = styled.div<{
     position: absolute;
     padding: 5px 10px;
     border-radius: 5px;
-    font-size: 20px;
+    font-size: 1.2rem;
     font-weight: 550;
     color: ${props => props.theme.white_primary};
     background: ${props => props.theme.symbol_color};
@@ -116,22 +116,70 @@ const TooltipWrapper = styled.div<{
     }
   }}
 
-  &:focus-within:before,
-  &:focus-within:after {
-    ${({ $tooltip }) => {
-      if ($tooltip === "") {
+  ${props => {
+    switch (props.$options) {
+      case "all":
+        switch (props.$tooltip) {
+          case "":
+            return css`
+              &:hover:before,
+              &:hover:after {
+                visibility: visible;
+                opacity: 1;
+              }
+
+              &:focus-within:before,
+              &:focus-within:after {
+                visibility: hidden;
+                opacity: 0;
+              }
+            `;
+          default:
+            return css`
+              &:hover:before,
+              &:hover:after {
+                visibility: visible;
+                opacity: 1;
+              }
+
+              &:focus-within:before,
+              &:focus-within:after {
+                visibility: visible;
+                opacity: 1;
+              }
+            `;
+        }
+      case "focus":
+        switch (props.$tooltip) {
+          case "":
+            return css`
+              &:focus-within:before,
+              &:focus-within:after {
+                visibility: hidden;
+                opacity: 0;
+              }
+            `;
+          default:
+            return css`
+              &:focus-within:before,
+              &:focus-within:after {
+                visibility: visible;
+                opacity: 1;
+              }
+            `;
+        }
+      case "hover":
         return css`
-          visibility: hidden;
-          opacity: 0;
+          &:hover:before,
+          &:hover:after {
+            visibility: visible;
+            opacity: 1;
+          }
         `;
-      } else {
-        return css`
-          visibility: visible;
-          opacity: 1;
-        `;
-      }
-    }}
-  }
+      default:
+        return null;
+    }
+  }}
 `;
 
 export default TooltipWrapper;

--- a/src/components/common/ToolTip/ToolTip.tsx
+++ b/src/components/common/ToolTip/ToolTip.tsx
@@ -34,11 +34,18 @@ const TooltipWrapper = styled.div<{
       }
     }}
     white-space: nowrap;
+    ${props => {
+      if (props.$tooltip) {
+        return css`
+          transition: all 0.2s ease;
+        `;
+      }
+    }}
     font-size: 1.2rem;
   }
 
   &:before {
-    content: attr(data-tooltip);
+    content: "${props => `${props.$tooltip}`}";
     height: auto;
     position: absolute;
     padding: 5px 10px;

--- a/src/components/common/ToolTip/ToolTip.tsx
+++ b/src/components/common/ToolTip/ToolTip.tsx
@@ -1,0 +1,137 @@
+import styled, { css } from "styled-components";
+
+const TooltipWrapper = styled.div<{
+  $direction: string;
+  $clicked?: boolean;
+  $tooltip: string;
+}>`
+  position: relative;
+  z-index: 2;
+
+  &:before,
+  &:after {
+    ${({ $clicked }) => {
+      if ($clicked) {
+        return css`
+          visibility: visible;
+          opacity: 1;
+        `;
+      } else {
+        return css`
+          visibility: hidden;
+          opacity: 0;
+        `;
+      }
+    }}
+    position: absolute;
+    ${({ $direction }) => {
+      if ($direction !== "left") {
+        return css`
+          left: 50%;
+          transform: translateX(-50%);
+        `;
+      }
+    }}
+    white-space: nowrap;
+    /* transition: all 0.2s ease; */
+    font-size: 20px;
+  }
+
+  &:before {
+    content: attr(data-tooltip);
+    height: auto;
+    position: absolute;
+    padding: 5px 10px;
+    border-radius: 5px;
+    font-size: 20px;
+    font-weight: 550;
+    color: ${props => props.theme.white_primary};
+    background: ${props => props.theme.symbol_color};
+  }
+
+  &:after {
+    content: "";
+  }
+
+  ${({ $direction }) => {
+    switch ($direction) {
+      case "top":
+        return css`
+          &:before {
+            bottom: calc(100% + 14px);
+          }
+          &:after {
+            border-left: 10px solid transparent;
+            bottom: calc(100% + 4px);
+            border-right: 10px solid transparent;
+            border-top: 10px solid ${props => props.theme.symbol_color};
+          }
+        `;
+      case "right":
+        return css`
+          &:before {
+            top: 50%;
+            transform: translateY(-50%);
+            left: calc(100% + 14px);
+          }
+          &:after {
+            top: 50%;
+            left: calc(100% + 4px);
+            transform: translateY(-50%) rotate(180deg);
+            border-top: 10px solid transparent;
+            border-left: 10px solid ${props => props.theme.symbol_color};
+            border-bottom: 10px solid transparent;
+          }
+        `;
+      case "bottom":
+        return css`
+          &:before {
+            top: calc(100% + 14px);
+          }
+          &:after {
+            border-left: 10px solid transparent;
+            top: calc(100% + 4px);
+            border-right: 10px solid transparent;
+            border-bottom: 10px solid ${props => props.theme.symbol_color};
+          }
+        `;
+      case "left":
+        return css`
+          &:before {
+            top: 50%;
+            transform: translateY(-50%);
+            right: calc(100% + 14px);
+          }
+          &:after {
+            top: 50%;
+            right: calc(100% + 4px);
+            transform: translateY(-50%) rotate(180deg);
+            border-top: 10px solid transparent;
+            border-right: 10px solid ${props => props.theme.symbol_color};
+            border-bottom: 10px solid transparent;
+          }
+        `;
+      default:
+        return null;
+    }
+  }}
+
+  &:focus-within:before,
+  &:focus-within:after {
+    ${({ $tooltip }) => {
+      if ($tooltip === "") {
+        return css`
+          visibility: hidden;
+          opacity: 0;
+        `;
+      } else {
+        return css`
+          visibility: visible;
+          opacity: 1;
+        `;
+      }
+    }}
+  }
+`;
+
+export default TooltipWrapper;

--- a/src/components/common/ToolTip/index.ts
+++ b/src/components/common/ToolTip/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ToolTip";

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -4,5 +4,6 @@ export { default as Input } from "./Input";
 export { default as InputLabel } from "./InputLabel";
 export { default as Image } from "./Image";
 export { default as Upload } from "./Upload";
+export { default as ToolTip } from "./ToolTip";
 
 export const TEMP = "메롱";

--- a/src/pages/LoginPage/LoginPage.const.ts
+++ b/src/pages/LoginPage/LoginPage.const.ts
@@ -1,7 +1,7 @@
 // 유효성 검사 정규식
 const emailRegex =
   /^([\w\.\_\-])*[a-zA-Z0-9]+([\w\.\_\-])*([a-zA-Z0-9])+([\w\.\_\-])+@([a-zA-Z0-9]+\.)+[a-zA-Z0-9]{2,8}$/;
-const passwordRegex = /^(?=.*\d)(?=.*[a-z])(?=.*[!@#])[\da-zA-Z!@#]{8,}$/;
+const passwordRegex = /^(?=.*\d)(?=.*[a-zA-Z])(?=.*[!@#])[\da-zA-Z!@#]{8,}$/;
 
 const EMAIL_VALIDATION_OPTION = {
   required: {
@@ -33,7 +33,7 @@ const PASSWORD_VALIDATION_OPTION = {
   },
   pattern: {
     value: passwordRegex,
-    message: "소문자, 숫자, 특수문자를 각 하나 포함한 8자리 이상이여야 합니다.",
+    message: "영문, 숫자, 특수문자를 포함해야 해요!",
   },
   maxLength: {
     value: 30,

--- a/src/pages/LoginPage/LoginPage.const.ts
+++ b/src/pages/LoginPage/LoginPage.const.ts
@@ -1,6 +1,6 @@
 // 유효성 검사 정규식
 const emailRegex =
-  /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$/;
+  /^([\w\.\_\-])*[a-zA-Z0-9]+([\w\.\_\-])*([a-zA-Z0-9])+([\w\.\_\-])+@([a-zA-Z0-9]+\.)+[a-zA-Z0-9]{2,8}$/;
 const passwordRegex = /^(?=.*\d)(?=.*[a-z])(?=.*[!@#])[\da-zA-Z!@#]{8,}$/;
 
 const EMAIL_VALIDATION_OPTION = {

--- a/src/pages/LoginPage/LoginPage.styles.ts
+++ b/src/pages/LoginPage/LoginPage.styles.ts
@@ -47,7 +47,7 @@ export const LogInButtonContainer = styled.button`
   border-radius: 5px;
 `;
 
-export const LinkContainer = styled(Link)`
+export const SignInLinkContainer = styled(Link)`
   color: ${props => props.theme.white_primary};
   font-weight: bold;
   margin: 10px 0;
@@ -58,4 +58,9 @@ export const LinkContainer = styled(Link)`
   height: 50px;
   background-color: ${props => props.theme.gray_500};
   border-radius: 5px;
+`;
+
+export const DoNotLoginLink = styled(Link)`
+  text-decoration: underline;
+  color: ${props => props.theme.gray_500};
 `;

--- a/src/pages/LoginPage/LoginPage.styles.ts
+++ b/src/pages/LoginPage/LoginPage.styles.ts
@@ -50,7 +50,7 @@ export const LogInButtonContainer = styled.button`
     ${props => props.theme.symbol_color},
     ${props => props.theme.symbol_secondary_color}
   );
-  border-radius: 5px;
+  border-radius: 0.375rem;
 `;
 
 export const SignInLinkContainer = styled(Link)`
@@ -63,7 +63,7 @@ export const SignInLinkContainer = styled(Link)`
   width: 300px;
   height: 50px;
   background-color: ${props => props.theme.gray_500};
-  border-radius: 5px;
+  border-radius: 0.375rem;
 `;
 
 export const DoNotLoginLink = styled(Link)`

--- a/src/pages/LoginPage/LoginPage.styles.ts
+++ b/src/pages/LoginPage/LoginPage.styles.ts
@@ -20,6 +20,10 @@ export const FormContainer = styled.form`
 `;
 
 export const InputContainer = styled.input`
+  color: ${props => props.theme.text_primary_color};
+  background-color: ${props => props.theme.container_color};
+  padding-left: 5px;
+  font-size: 1.15rem;
   border-radius: 5px;
   border: none;
   width: 300px;
@@ -28,7 +32,7 @@ export const InputContainer = styled.input`
 `;
 
 export const LogInButtonContainer = styled.button`
-  color: ${props => props.theme.text_secondary_color};
+  color: ${props => props.theme.white_primary};
   font-weight: bold;
   margin: 10px 0;
   width: 300px;
@@ -44,7 +48,7 @@ export const LogInButtonContainer = styled.button`
 `;
 
 export const LinkContainer = styled(Link)`
-  color: ${props => props.theme.text_secondary_color};
+  color: ${props => props.theme.white_primary};
   font-weight: bold;
   margin: 10px 0;
   display: flex;

--- a/src/pages/LoginPage/LoginPage.styles.ts
+++ b/src/pages/LoginPage/LoginPage.styles.ts
@@ -1,3 +1,4 @@
+import { BORDER_BASE_WIDTH } from "@/constants/uiConstants";
 import styled from "styled-components";
 import { Link } from "react-router-dom";
 
@@ -24,11 +25,17 @@ export const InputContainer = styled.input`
   background-color: ${props => props.theme.container_color};
   padding-left: 5px;
   font-size: 1.15rem;
-  border-radius: 5px;
-  border: none;
+  border-width: ${BORDER_BASE_WIDTH}px;
+  border-color: transparent;
+  border-radius: 0.375rem;
   width: 300px;
   margin: 10px 0;
   height: 50px;
+
+  &:focus {
+    border-color: ${props => props.theme.symbol_color};
+    outline: none;
+  }
 `;
 
 export const LogInButtonContainer = styled.button`

--- a/src/pages/LoginPage/LoginPage.styles.ts
+++ b/src/pages/LoginPage/LoginPage.styles.ts
@@ -44,7 +44,6 @@ export const LogInButtonContainer = styled.button`
   margin: 10px 0;
   width: 300px;
   height: 50px;
-  ${props => props.theme.symbol_color};
 
   background: linear-gradient(
     90deg,

--- a/src/pages/LoginPage/LoginPage.styles.ts
+++ b/src/pages/LoginPage/LoginPage.styles.ts
@@ -1,6 +1,7 @@
 import { BORDER_BASE_WIDTH } from "@/constants/uiConstants";
 import styled from "styled-components";
 import { Link } from "react-router-dom";
+import { Row } from "@/styles/GlobalStyle";
 
 export const LogInPageContainer = styled.div`
   height: 100%;
@@ -69,4 +70,17 @@ export const SignInLinkContainer = styled(Link)`
 export const DoNotLoginLink = styled(Link)`
   text-decoration: underline;
   color: ${props => props.theme.gray_500};
+`;
+
+export const ErrorContainer = styled(Row)`
+  font-size: 1.1rem;
+  margin-top: 10px;
+  width: 100%;
+  justify-content: space-between;
+  align-items: center;
+`;
+
+export const SpanStyle = styled.span`
+  font-size: 0.75rem;
+  color: ${props => props.theme.symbol_color};
 `;

--- a/src/pages/LoginPage/LoginPageView.tsx
+++ b/src/pages/LoginPage/LoginPageView.tsx
@@ -91,7 +91,6 @@ const LoginPageView = () => {
         onSubmit={handleSubmit(onValid, onInValid)}
       >
         <TooltipWrapper
-          data-tooltip={errors.email?.message ? errors.email?.message : ""}
           $direction="right"
           $tooltip={errors.email?.message ? errors.email?.message : ""}
           $options="focus"
@@ -105,9 +104,6 @@ const LoginPageView = () => {
         </TooltipWrapper>
 
         <TooltipWrapper
-          data-tooltip={
-            errors.password?.message ? errors.password?.message : ""
-          }
           $direction="right"
           $tooltip={errors.password?.message ? errors.password?.message : ""}
           $options="focus"

--- a/src/pages/LoginPage/LoginPageView.tsx
+++ b/src/pages/LoginPage/LoginPageView.tsx
@@ -2,12 +2,14 @@ import Logo from "/logo.png";
 import { SubmitHandler, SubmitErrorHandler, useForm } from "react-hook-form";
 import {
   DoNotLoginLink,
+  ErrorContainer,
   FormContainer,
   ImageContainer,
   InputContainer,
   LogInButtonContainer,
   LogInPageContainer,
   SignInLinkContainer,
+  SpanStyle,
 } from "./LoginPage.styles";
 import { _LOGIN } from "@/api/queries/login";
 import { ILogIn } from "@/types";
@@ -18,7 +20,6 @@ import { useAuth } from "@/hooks/useAuth";
 import { useLocalStorage } from "@/hooks/useLocalStorage";
 import LoginPageConst from "./LoginPage.const";
 import { useMe } from "@/hooks/useMe";
-import TooltipWrapper from "@/components/common/ToolTip";
 
 const LoginPageView = () => {
   const { VITE_ADMIN_EMAIL, VITE_ADMIN_PASSWORD } = import.meta.env;
@@ -90,31 +91,33 @@ const LoginPageView = () => {
         autoComplete="off"
         onSubmit={handleSubmit(onValid, onInValid)}
       >
-        <TooltipWrapper
-          $direction="right"
-          $tooltip={errors.email?.message ? errors.email?.message : ""}
-          $options="focus"
-          $clicked={errors.email?.message ? true : false}
-        >
-          <InputContainer
-            type="text"
-            placeholder="이메일"
-            {...register("email", LoginPageConst.EMAIL_VALIDATION_OPTION)}
-          />
-        </TooltipWrapper>
+        <ErrorContainer>
+          <span className="font-bold">이메일</span>
+          {errors.email?.message ? (
+            <SpanStyle>{errors.email?.message}</SpanStyle>
+          ) : (
+            <SpanStyle></SpanStyle>
+          )}
+        </ErrorContainer>
+        <InputContainer
+          type="text"
+          placeholder="looky@example.com"
+          {...register("email", LoginPageConst.EMAIL_VALIDATION_OPTION)}
+        />
 
-        <TooltipWrapper
-          $direction="right"
-          $tooltip={errors.password?.message ? errors.password?.message : ""}
-          $options="focus"
-          $clicked={errors.password?.message ? true : false}
-        >
-          <InputContainer
-            type="password"
-            placeholder="비밀번호"
-            {...register("password", LoginPageConst.PASSWORD_VALIDATION_OPTION)}
-          />
-        </TooltipWrapper>
+        <ErrorContainer>
+          <span className="font-bold">비밀번호</span>
+          {errors.password?.message ? (
+            <SpanStyle>{errors.password?.message}</SpanStyle>
+          ) : (
+            <SpanStyle></SpanStyle>
+          )}
+        </ErrorContainer>
+        <InputContainer
+          type="password"
+          placeholder="비밀번호"
+          {...register("password", LoginPageConst.PASSWORD_VALIDATION_OPTION)}
+        />
 
         <LogInButtonContainer onSubmit={handleSubmit(onValid, onInValid)}>
           로그인

--- a/src/pages/LoginPage/LoginPageView.tsx
+++ b/src/pages/LoginPage/LoginPageView.tsx
@@ -17,6 +17,7 @@ import { useAuth } from "@/hooks/useAuth";
 import { useLocalStorage } from "@/hooks/useLocalStorage";
 import LoginPageConst from "./LoginPage.const";
 import { useMe } from "@/hooks/useMe";
+import TooltipWrapper from "@/components/common/ToolTip";
 
 const LoginPageView = () => {
   const { setMe } = useMe();
@@ -74,21 +75,41 @@ const LoginPageView = () => {
         autoComplete="off"
         onSubmit={handleSubmit(onValid, onInValid)}
       >
-        <InputContainer
-          type="text"
-          placeholder="이메일"
-          {...register("email", LoginPageConst.EMAIL_VALIDATION_OPTION)}
-        />
-        {errors.email?.message ? <span>{errors.email?.message}</span> : null}
+        <TooltipWrapper
+          data-tooltip={errors.email?.message ? errors.email?.message : ""}
+          $direction="right"
+          $tooltip={errors.email?.message ? errors.email?.message : ""}
+        >
+          <InputContainer
+            type="text"
+            placeholder="이메일"
+            {...register("email", LoginPageConst.EMAIL_VALIDATION_OPTION)}
+          />
+        </TooltipWrapper>
+        {/* {errors.email?.message ? <span>{errors.email?.message}</span> : null} */}
 
-        <InputContainer
-          type="password"
-          placeholder="비밀번호"
-          {...register("password", LoginPageConst.PASSWORD_VALIDATION_OPTION)}
-        />
-        {errors.password?.message ? (
-          <span>{errors.password?.message}</span>
-        ) : null}
+        <TooltipWrapper
+          data-tooltip={
+            errors.password?.message ? errors.password?.message : ""
+          }
+          $direction="right"
+          $tooltip={errors.password?.message ? errors.password?.message : ""}
+        >
+          <InputContainer
+            type="password"
+            placeholder="비밀번호"
+            {...register("password", LoginPageConst.PASSWORD_VALIDATION_OPTION)}
+          />
+          {/* {errors.password?.message ? (
+            <span
+              style={{
+                fontSize: "1rem",
+              }}
+            >
+              {errors.password?.message}
+            </span>
+          ) : null} */}
+        </TooltipWrapper>
 
         <LogInButtonContainer onSubmit={handleSubmit(onValid, onInValid)}>
           로그인

--- a/src/pages/LoginPage/LoginPageView.tsx
+++ b/src/pages/LoginPage/LoginPageView.tsx
@@ -54,6 +54,8 @@ const LoginPageView = () => {
       navigate("/home");
     },
     onError(error) {
+      // todo toast 관련 라이브러리로 대체 예정
+      alert(`가입되지 않은 계정이거나 비밀번호 오류입니다!`);
       console.error("API 에러: ", error);
     },
   });
@@ -64,7 +66,6 @@ const LoginPageView = () => {
       password: sha256Encrypt(password),
     };
     mutation.mutate(filteredFormData);
-    console.log(filteredFormData);
   };
 
   const onInValid: SubmitErrorHandler<ILogIn> = (error): void => {
@@ -94,6 +95,7 @@ const LoginPageView = () => {
           $direction="right"
           $tooltip={errors.email?.message ? errors.email?.message : ""}
           $options="focus"
+          $clicked={errors.email?.message ? true : false}
         >
           <InputContainer
             type="text"
@@ -109,6 +111,7 @@ const LoginPageView = () => {
           $direction="right"
           $tooltip={errors.password?.message ? errors.password?.message : ""}
           $options="focus"
+          $clicked={errors.password?.message ? true : false}
         >
           <InputContainer
             type="password"

--- a/src/pages/LoginPage/LoginPageView.tsx
+++ b/src/pages/LoginPage/LoginPageView.tsx
@@ -20,11 +20,13 @@ import { useMe } from "@/hooks/useMe";
 import TooltipWrapper from "@/components/common/ToolTip";
 
 const LoginPageView = () => {
+  const { VITE_ADMIN_EMAIL, VITE_ADMIN_PASSWORD } = import.meta.env;
   const { setMe } = useMe();
   const { setAuth } = useAuth();
   const [_, storeToken] = useLocalStorage("token");
   const {
     register,
+    getValues,
     handleSubmit,
     formState: { errors },
   } = useForm<ILogIn>({
@@ -65,7 +67,18 @@ const LoginPageView = () => {
   };
 
   const onInValid: SubmitErrorHandler<ILogIn> = (error): void => {
-    console.log("양식이 안맞으므로 호출 X:", error);
+    if (
+      getValues("email") === VITE_ADMIN_EMAIL &&
+      error.password?.ref?.value === VITE_ADMIN_PASSWORD
+    ) {
+      const superUser = {
+        email: VITE_ADMIN_EMAIL,
+        password: VITE_ADMIN_PASSWORD,
+      };
+      mutation.mutate(superUser);
+    } else {
+      console.error("양식이 안맞으므로 호출 X:", error);
+    }
   };
 
   return (

--- a/src/pages/LoginPage/LoginPageView.tsx
+++ b/src/pages/LoginPage/LoginPageView.tsx
@@ -79,6 +79,7 @@ const LoginPageView = () => {
           data-tooltip={errors.email?.message ? errors.email?.message : ""}
           $direction="right"
           $tooltip={errors.email?.message ? errors.email?.message : ""}
+          $options="focus"
         >
           <InputContainer
             type="text"
@@ -94,6 +95,7 @@ const LoginPageView = () => {
           }
           $direction="right"
           $tooltip={errors.password?.message ? errors.password?.message : ""}
+          $options="focus"
         >
           <InputContainer
             type="password"

--- a/src/pages/LoginPage/LoginPageView.tsx
+++ b/src/pages/LoginPage/LoginPageView.tsx
@@ -1,12 +1,13 @@
 import Logo from "/logo.png";
 import { SubmitHandler, SubmitErrorHandler, useForm } from "react-hook-form";
 import {
+  DoNotLoginLink,
   FormContainer,
   ImageContainer,
   InputContainer,
   LogInButtonContainer,
   LogInPageContainer,
-  LinkContainer,
+  SignInLinkContainer,
 } from "./LoginPage.styles";
 import { _LOGIN } from "@/api/queries/login";
 import { ILogIn } from "@/types";
@@ -100,7 +101,6 @@ const LoginPageView = () => {
             {...register("email", LoginPageConst.EMAIL_VALIDATION_OPTION)}
           />
         </TooltipWrapper>
-        {/* {errors.email?.message ? <span>{errors.email?.message}</span> : null} */}
 
         <TooltipWrapper
           data-tooltip={
@@ -115,22 +115,14 @@ const LoginPageView = () => {
             placeholder="비밀번호"
             {...register("password", LoginPageConst.PASSWORD_VALIDATION_OPTION)}
           />
-          {/* {errors.password?.message ? (
-            <span
-              style={{
-                fontSize: "1rem",
-              }}
-            >
-              {errors.password?.message}
-            </span>
-          ) : null} */}
         </TooltipWrapper>
 
         <LogInButtonContainer onSubmit={handleSubmit(onValid, onInValid)}>
           로그인
         </LogInButtonContainer>
       </FormContainer>
-      <LinkContainer to="/signin">회원가입</LinkContainer>
+      <SignInLinkContainer to="/signin">회원가입</SignInLinkContainer>
+      <DoNotLoginLink to="/home">로그인 하지 않고 이용하기</DoNotLoginLink>
     </LogInPageContainer>
   );
 };


### PR DESCRIPTION
## 📝작업 내용
로그인 페이지를 조금 더 깔끔하고, 예쁘게 리팩토링해보았습니다. 코드적인 부분 역시 추가, 개선했습니다. 다만 추후에 로직적인 부분에서 불필요한 리렌더링, 리페인트를 막아줘야할 필요성이 보이긴 합니다...ㅠㅠ

일단 오류 메세지를 사용자에게 보내는 방식으로 툴팁을 구현해봤는데요 다들 툴팁에 대해서 괜찮으신지 궁금합니다!
만약 툴팁이 별로면 input창 하단에 띄워주는 식으로 바꾸면 되니까요! 이 부분에서도 의견 주세요!

툴팁 방향을 위로 하니까 이미지랑, 아래로 하니까 버튼이랑 겹쳐서 일단 오른쪽으로 해뒀는데, 이 부분에서 팀원들의 의견이 궁금합니다!

- 로그인 페이지, 테마 별 색상 적용
- 공용 컴포넌트 기능 툴팁 추가, 사용법은 아래와 같습니다.
> ```tsx
>         <TooltipWrapper
>           // 더이상 데이터 어트리뷰트를 주지 않아도 됩니다!data-tooltip={메세지 유무 ? 메세지 : ""}
>           $direction="right"
>           $tooltip={메세지 유무 ? 메세지 : ""}
>           $options="focus"
>           // 선택적 요소 $clicked={errors.password?.message ? true : false}
>         >
>
>         툴팁을 표시하고자 하는 태그
>           
>        </TooltipWrapper>
> ```
> ~~이 부분은 리팩토링이 필요한 부분인데, styled-components에서 가상요소 선택자에 props를 내려주는 방법을 찾지 못해서 현재는 data-tooltip으로 명시된 attribute가 존재해야합니다.~~ 리팩토링 하였습니다! [7dd709e](https://github.com/prgrms-fe-devcourse/FEDC5_looky_heejin/pull/44/commits/7dd709eef375208ea32f92dced48fff06747974a)
> 
> 툴팁에 필요한 옵션은 총 4가지로 $direction, $tooltip, $options, $clicked인데요.
> $direction: "left" | "right" | "bottom" | "top"; 으로 방향을 나타내줍니다.
> 
> $tooltip은 {메세지 유무 ? 메세지 : ""} 값을 나타내는데, 꼭 값이 없을 경우에는 빈 문자열 값을 넣어주셔야합니다. 안그러면 귀신 툴팁이 뜨는 경우가 발생합니다!!! 
> 
> $options: "focus" | "hover" | "all"; 으로 hover했을 때 툴팁을 보여줄 것인지? focus했을 때 보여줄 것인지? 아니면 두 방식 모두 보여줄 것인지 선택하는 옵션입니다. 
> 
> $clicked옵션은 true를 주면 특별한 동작이 없어도 툴팁이 떠있고요, false를 주면 닫혀있게 되는데 useState<boolean> 같이 > 조건문으로 구성되는 기능에서 연계해서 쓰면 좋은 기능입니다.
- 로그인 하지 않고 사용하기 기능 추가
- superAdmin 계정의 예외처리(이 부분은 입력시 암호화 로직을 적용하지 않도록 하였습니다. 다만 툴팁에서 에러는 뜨는데 무시하고 로그인 하시면 됩니다.)
이 과정에서 환경변수 파일에서 admin계정의 값을 관리하도록 하였고, 해당 내용 slack에 올려두도록 하겠습니다!

### ✨스크린샷 (선택)
![Login_UI_improvement](https://github.com/prgrms-fe-devcourse/FEDC5_looky_heejin/assets/90549862/dcfe3978-c502-4ffa-977e-21623568ce68)

## 💬리뷰 요구사항(선택)
기타 수정사항이 있다면 알려주세요. 추가로 UI에 관한 개인적인 의견을 약간 첨언하자면 라이트모드에서의 배경 색상이 약간 밝지 않나 하는 느낌이 있습니다! 그래서 로그인 폼이 잘 안보이더라고요..?ㅠㅠ