### PR TITLE
Feature/top-nav-bar 0.2.2

### DIFF
--- a/src/components/common/Navigator/TopNavBar/Elements/ChatNotificationIconsBox.tsx
+++ b/src/components/common/Navigator/TopNavBar/Elements/ChatNotificationIconsBox.tsx
@@ -26,8 +26,9 @@ const IconsBox = styled.div`
   }
 `;
 
-const IconWrapper = styled.div`
+const IconWrapper = styled.div<{ $marginLeft: string }>`
   margin: auto 0.25rem;
+  margin-left: ${({ $marginLeft }) => $marginLeft && $marginLeft};
   & > :first-child {
     cursor: pointer;
   }
@@ -83,7 +84,7 @@ const ChatNotificationIconsBox = ({
 
   return (
     <IconsBox>
-      <IconWrapper onClick={handleTheme}>
+      <IconWrapper onClick={handleTheme} $marginLeft={id ? "" : "4.5rem"}>
         <Icon
           name={theme.theme_mode === "light" ? LIGHTMODE_ICON : DARKMODE_ICON}
           size="1.6rem"
@@ -92,7 +93,10 @@ const ChatNotificationIconsBox = ({
       </IconWrapper>
       {id ? (
         <>
-          <NotificationIconWrapper onClick={() => onClick(PathName.CHATS)}>
+          <NotificationIconWrapper
+            $marginLeft={""}
+            onClick={() => onClick(PathName.CHATS)}
+          >
             <Icon name={CHAT_ICON} size="1.6rem" weight={250}></Icon>
             {messageUnseenCount > 0 ? (
               <ChatNotificationCounter>
@@ -103,6 +107,7 @@ const ChatNotificationIconsBox = ({
             ) : null}
           </NotificationIconWrapper>
           <NotificationIconWrapper
+            $marginLeft={""}
             onClick={() => onClick(PathName.NOTIFICATIONS)}
           >
             <Icon name={NOTIFICATIONS_ICON} size="1.7rem" weight={250}></Icon>

--- a/src/components/common/Navigator/TopNavBar/Elements/ChatNotificationIconsBox.tsx
+++ b/src/components/common/Navigator/TopNavBar/Elements/ChatNotificationIconsBox.tsx
@@ -9,6 +9,7 @@ import {
 import { PathName } from "@/constants/pathNameConstants";
 import { useLocalStorage } from "@/hooks/useLocalStorage";
 import { useMe } from "@/hooks/useMe";
+import { useNotification } from "@/hooks/useNotification";
 
 interface IChatNotificationIconsBoxProps {
   onClick: (path: string) => void;
@@ -33,10 +34,22 @@ const IconWrapper = styled.div`
 `;
 
 const NotificationIconWrapper = styled(IconWrapper)`
-  & > :last-child {
+  margin: auto 0.25rem;
+  & > * {
     cursor: pointer;
   }
   position: relative;
+`;
+
+const ChatNotificationCounter = styled.div`
+  position: absolute;
+  left: 0.9rem;
+  top: 0.1rem;
+  width: 1rem;
+  height: 1rem;
+  background-color: ${({ theme }) => theme.symbol_color};
+  border-radius: 50%;
+  border: ${({ theme }) => `1px solid ${theme.background_color}`};
 `;
 
 const NotificationCounter = styled.div`
@@ -60,6 +73,7 @@ const ChatNotificationIconsBox = ({
   onClick,
 }: IChatNotificationIconsBoxProps) => {
   const { id } = useMe();
+  const { commonUnseenCount, common, messageUnseenCount } = useNotification();
   const theme = useTheme();
   const [_, setLocalTheme] = useLocalStorage("theme");
 
@@ -67,6 +81,7 @@ const ChatNotificationIconsBox = ({
     setLocalTheme(theme.theme_mode === "light" ? "dark" : "light");
   };
 
+  console.log(common, commonUnseenCount, messageUnseenCount);
   return (
     <IconsBox>
       <IconWrapper onClick={handleTheme}>
@@ -78,16 +93,27 @@ const ChatNotificationIconsBox = ({
       </IconWrapper>
       {id ? (
         <>
-          <IconWrapper onClick={() => onClick(PathName.CHATS)}>
+          <NotificationIconWrapper onClick={() => onClick(PathName.CHATS)}>
             <Icon name={CHAT_ICON} size="1.6rem" weight={250}></Icon>
-          </IconWrapper>
+            {messageUnseenCount > 0 ? (
+              <ChatNotificationCounter>
+                <NotificationCounterSpan>
+                  {Math.min(messageUnseenCount, 99)}
+                </NotificationCounterSpan>
+              </ChatNotificationCounter>
+            ) : null}
+          </NotificationIconWrapper>
           <NotificationIconWrapper
             onClick={() => onClick(PathName.NOTIFICATIONS)}
           >
             <Icon name={NOTIFICATIONS_ICON} size="1.7rem" weight={250}></Icon>
-            <NotificationCounter>
-              <NotificationCounterSpan>20</NotificationCounterSpan>
-            </NotificationCounter>
+            {commonUnseenCount > 0 ? (
+              <NotificationCounter>
+                <NotificationCounterSpan>
+                  {Math.min(commonUnseenCount, 99)}
+                </NotificationCounterSpan>
+              </NotificationCounter>
+            ) : null}
           </NotificationIconWrapper>
         </>
       ) : null}

--- a/src/components/common/Navigator/TopNavBar/Elements/ChatNotificationIconsBox.tsx
+++ b/src/components/common/Navigator/TopNavBar/Elements/ChatNotificationIconsBox.tsx
@@ -1,4 +1,4 @@
-import styled, { useTheme } from "styled-components";
+import styled, { keyframes, useTheme } from "styled-components";
 import Icon from "../../../Icon/Icon";
 import {
   CHAT_ICON,
@@ -14,6 +14,15 @@ import { useNotification } from "@/hooks/useNotification";
 interface IChatNotificationIconsBoxProps {
   onClick: (path: string) => void;
 }
+
+export const zoomin = keyframes`
+  0% {
+    transform: scale(1);
+  }
+  100% {
+    transform: scale(1.1);
+  }
+`;
 
 const IconsBox = styled.div`
   display: flex;
@@ -31,6 +40,9 @@ const IconWrapper = styled.div<{ $marginLeft: string }>`
   margin-left: ${({ $marginLeft }) => $marginLeft && $marginLeft};
   & > :first-child {
     cursor: pointer;
+  }
+  &:hover > :first-child {
+    animation: ${zoomin} 0.4s ease-in-out forwards;
   }
 `;
 

--- a/src/components/common/Navigator/TopNavBar/Elements/ChatNotificationIconsBox.tsx
+++ b/src/components/common/Navigator/TopNavBar/Elements/ChatNotificationIconsBox.tsx
@@ -18,8 +18,8 @@ const IconsBox = styled.div`
   display: flex;
   flex-direction: row;
   justify-content: center;
-  gap: 5px;
-  margin: auto 0;
+  gap: 2px;
+  margin: auto 1rem auto 0;
   & > :nth-child(2) {
     padding-top: 0.3rem;
   }

--- a/src/components/common/Navigator/TopNavBar/Elements/ChatNotificationIconsBox.tsx
+++ b/src/components/common/Navigator/TopNavBar/Elements/ChatNotificationIconsBox.tsx
@@ -43,7 +43,7 @@ const NotificationIconWrapper = styled(IconWrapper)`
 
 const ChatNotificationCounter = styled.div`
   position: absolute;
-  left: 0.9rem;
+  left: 0.95rem;
   top: 0.1rem;
   width: 1rem;
   height: 1rem;
@@ -73,7 +73,7 @@ const ChatNotificationIconsBox = ({
   onClick,
 }: IChatNotificationIconsBoxProps) => {
   const { id } = useMe();
-  const { commonUnseenCount, common, messageUnseenCount } = useNotification();
+  const { commonUnseenCount, messageUnseenCount } = useNotification();
   const theme = useTheme();
   const [_, setLocalTheme] = useLocalStorage("theme");
 
@@ -81,7 +81,6 @@ const ChatNotificationIconsBox = ({
     setLocalTheme(theme.theme_mode === "light" ? "dark" : "light");
   };
 
-  console.log(common, commonUnseenCount, messageUnseenCount);
   return (
     <IconsBox>
       <IconWrapper onClick={handleTheme}>

--- a/src/components/common/Navigator/TopNavBar/Elements/ChatNotificationIconsBox.tsx
+++ b/src/components/common/Navigator/TopNavBar/Elements/ChatNotificationIconsBox.tsx
@@ -32,6 +32,30 @@ const IconWrapper = styled.div`
   }
 `;
 
+const NotificationIconWrapper = styled(IconWrapper)`
+  & > :last-child {
+    cursor: pointer;
+  }
+  position: relative;
+`;
+
+const NotificationCounter = styled.div`
+  position: absolute;
+  left: 0.9rem;
+  width: 1rem;
+  height: 1rem;
+  background-color: ${({ theme }) => theme.symbol_color};
+  border-radius: 50%;
+  border: ${({ theme }) => `1px solid ${theme.background_color}`};
+`;
+
+const NotificationCounterSpan = styled.span`
+  margin: auto auto;
+  font-size: 0.45rem;
+  font-weight: 500;
+  color: #ffffff;
+`;
+
 const ChatNotificationIconsBox = ({
   onClick,
 }: IChatNotificationIconsBoxProps) => {
@@ -57,9 +81,14 @@ const ChatNotificationIconsBox = ({
           <IconWrapper onClick={() => onClick(PathName.CHATS)}>
             <Icon name={CHAT_ICON} size="1.6rem" weight={250}></Icon>
           </IconWrapper>
-          <IconWrapper onClick={() => onClick(PathName.NOTIFICATIONS)}>
+          <NotificationIconWrapper
+            onClick={() => onClick(PathName.NOTIFICATIONS)}
+          >
             <Icon name={NOTIFICATIONS_ICON} size="1.7rem" weight={250}></Icon>
-          </IconWrapper>
+            <NotificationCounter>
+              <NotificationCounterSpan>20</NotificationCounterSpan>
+            </NotificationCounter>
+          </NotificationIconWrapper>
         </>
       ) : null}
     </IconsBox>

--- a/src/components/common/Navigator/TopNavBar/Elements/LogoImage.tsx
+++ b/src/components/common/Navigator/TopNavBar/Elements/LogoImage.tsx
@@ -7,7 +7,7 @@ interface ILogoImageProps {
 }
 
 const StyledImg = styled.img`
-  width: 50%;
+  width: 4rem;
   margin: auto auto;
   cursor: pointer;
 `;

--- a/src/components/common/Navigator/TopNavBar/TopNavBar.tsx
+++ b/src/components/common/Navigator/TopNavBar/TopNavBar.tsx
@@ -15,9 +15,9 @@ import useEventQuery from "@/hooks/useEventQuery";
 import { useMe } from "@/hooks/useMe";
 import { useLocalStorage } from "@/hooks/useLocalStorage";
 
-const LEFT_PARTITION_WIDTH = "20%";
-const CENTER_PARTITION_WIDTH = "60%";
-const RIGHT_PARTITION_WIDTH = "20%";
+const LEFT_PARTITION_WIDTH = "25%";
+const CENTER_PARTITION_WIDTH = "50%";
+const RIGHT_PARTITION_WIDTH = "25%";
 
 const TopNavBarWrapper = styled.nav`
   position: fixed;

--- a/src/store/reducers/notificationReducer.ts
+++ b/src/store/reducers/notificationReducer.ts
@@ -25,12 +25,12 @@ const notificationSlice = createSlice({
       state.message = action.payload.message;
 
       state.commonUnseenCount = _.chain(action.payload.common)
-        .countBy(data => !data.seem)
+        .countBy(data => !data.seen)
         .get("true", 0)
         .value();
 
       state.messageUnseenCount = _.chain(action.payload.message)
-        .countBy(data => !data.seem)
+        .countBy(data => !data.seen)
         .get("true", 0)
         .value();
     },


### PR DESCRIPTION
## 📝작업 내용
- 모바일에서 TopNavBar 레이아웃이 무너지는 현상을 해결했습니다.
- 메시지, 알림 아이콘에 받은 알림들의 개수를 표시했습니다.
  - useNotification 훅의 commonUnSeenCount, messageUnseenCount 를 사용했는데 의도에 맞게 사용되었는지 확인 부탁드립니다.
  - 99개가 넘는 알림 카운트는 99개만 표시되도록 구현했습니다.
  - 2개 계정을 통해 서로 알림보내고 잘 쌓이는지 확인 해본결과 알림 카운트가 정상적으로 증가합니다. 그런데 화면상 렌더링 된 알림들의 개수랑 알림 카운트랑 좀 다르네요 ㅠ,, 
  - 또, 알림 아이콘을 통해 한번 확인하면, 확인한 알림의 개수를 줄이거나, 빨간 점을 없애거나 해야할 것 같은데 월요일 스크럼때 같이 고민해봐야 할 것 같아요. 우선 생각한 방법으로는 아이콘을 누르는 순간 put 요청으로 모든 알림에 대해 읽음처리 하는 것 등이 있습니다.
- 아이콘 hover 시 scale이 증가하는 간단한 애니메이션을 넣었습니다.

### ✨스크린샷 (선택)
<img width="396" alt="스크린샷 2024-01-14 오후 1 53 24" src="https://github.com/prgrms-fe-devcourse/FEDC5_looky_heejin/assets/124658938/282d4dd5-4019-4cd9-9108-08c6169a9f73">

