### PR TITLE
Feature/TopNavBar-0.2.3

### DIFF
--- a/src/components/common/Navigator/TopNavBar/Elements/ChatAvatars.tsx
+++ b/src/components/common/Navigator/TopNavBar/Elements/ChatAvatars.tsx
@@ -1,8 +1,10 @@
+import { useNavigate } from "react-router-dom";
 import { Avatar } from "../../..";
 import { styled } from "styled-components";
 
 interface IChatAvatarsProps {
   myAvatarSrc: string | undefined;
+  partnerId: string | null;
   partnerAvatarSrc: string | undefined;
   partnerName: string;
 }
@@ -18,12 +20,18 @@ const AvatarsWrapper = styled.div`
   flex-direction: row;
   justify-content: center;
   margin: auto 0;
+  & :hover {
+    cursor: pointer;
+  }
 `;
 
-const AvatarWrapper = styled.div`
+const PartnerAvatarWrapper = styled.div`
   z-index: 99;
   & :first-child {
     margin-right: -0.8rem;
+  }
+  & :hover {
+    cursor: pointer;
   }
 `;
 
@@ -31,19 +39,28 @@ const PartnerName = styled.span`
   font-size: 0.7rem;
   font-weight: 500;
   margin: 0.15rem auto 0 auto;
+
+  cursor: pointer;
 `;
 
 const ChatAvatars = ({
   myAvatarSrc,
+  partnerId,
   partnerAvatarSrc,
   partnerName,
 }: IChatAvatarsProps) => {
+  const navigate = useNavigate();
+
+  const handlePartnerAvatar = (partnerId: string | null) => {
+    navigate(`/profile/${partnerId}`);
+  };
+
   return (
-    <ChatAvatarsWrapper>
+    <ChatAvatarsWrapper onClick={() => handlePartnerAvatar(partnerId)}>
       <AvatarsWrapper>
-        <AvatarWrapper>
+        <PartnerAvatarWrapper>
           <Avatar size="XXS" shape="circle" src={partnerAvatarSrc} />
-        </AvatarWrapper>
+        </PartnerAvatarWrapper>
         <Avatar size="XXS" shape="circle" src={myAvatarSrc} />
       </AvatarsWrapper>
       <PartnerName>{partnerName}</PartnerName>

--- a/src/components/common/Navigator/TopNavBar/TopNavBar.tsx
+++ b/src/components/common/Navigator/TopNavBar/TopNavBar.tsx
@@ -128,6 +128,7 @@ const TopNavBar = () => {
           {currentPath === PathName.CHAT && (
             <ChatAvatars
               myAvatarSrc={myProfileImage || undefined}
+              partnerId={partnerId}
               partnerAvatarSrc={partnerData.profileImage || undefined}
               partnerName={partnerData.fullName}
             />

--- a/src/components/common/Navigator/TopNavBar/TopNavBar.tsx
+++ b/src/components/common/Navigator/TopNavBar/TopNavBar.tsx
@@ -82,7 +82,7 @@ const TopNavBar = () => {
   });
 
   useEffect(() => {
-    if (currentPath === PathName.CHAT) {
+    if (currentPath === PathName.CHAT || currentPath === PathName.PROFILE) {
       const getPartnerData = async () => {
         const data = (await refetch()).data;
         setPartnerData({


### PR DESCRIPTION
## 📝작업 내용
- 프로필 페이지에서 채팅하기 버튼을 누르면 TopNavBar의 채팅 아바타가 이전 채팅 상대의 아바타가 렌더링되는 버그를 해결했습니다.
  - useEffect 의 콜백함수에서 pathname이 /chat일때만 setParterData 함수를 통해 대화 상대의 정보를 갱신해주고 있었는데, 알고보니 프로필 페이지의 pathname이 /profile 이니까 갱신이 안되는거였네요,, 최선의 방법은 아닐것같지만 /profile 일 경우에도 대화 상대의 정보를 갱신해줌으로써 일단 버그를 해결했습니다. 정상적으로 동작됩니다.
- 채팅중인 상대의 아바타를 클릭 시 상대방의 프로필로 이동할 수 있도록 코드를 추가했습니다.

### ✨스크린샷 (선택)

https://github.com/prgrms-fe-devcourse/FEDC5_looky_heejin/assets/124658938/fedde32e-4126-4ec5-a165-9bd2cbdbf4d6

