### PR TITLE
refactor: MVC 패턴 적용 - CreatePostPage 파일 분할

### DIFF
--- a/src/pages/CreatePostPage/CreatePostPage.controller.tsx
+++ b/src/pages/CreatePostPage/CreatePostPage.controller.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { FieldErrors, useForm } from "react-hook-form";
 
-import { _GET, _POST, rootAPI } from "@/api";
+import { rootAPI } from "@/api";
 import { ITag } from "@/types/post";
 import { useUI } from "@/components/common/uiContext";
 import { notify } from "@/utils/toast";

--- a/src/pages/CreatePostPage/CreatePostPage.controller.tsx
+++ b/src/pages/CreatePostPage/CreatePostPage.controller.tsx
@@ -1,0 +1,137 @@
+import { useEffect, useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { FieldErrors, useForm } from "react-hook-form";
+
+import { _GET, _POST, rootAPI } from "@/api";
+import { ITag } from "@/types/post";
+import { useUI } from "@/components/common/uiContext";
+import { notify } from "@/utils/toast";
+import { useLocalStorage } from "@/hooks/useLocalStorage";
+import CreatePostPageView from "./CreatePostPage.view";
+import { useCreatePostMutation } from "./CreatePostPage.model";
+
+export interface ICreatePostFormProps {
+  title: string;
+  content?: string;
+  file: File;
+  channelId: string;
+}
+
+export interface IPostBodyData {
+  title: string;
+  image: File;
+  channelId: string;
+}
+
+const CreatePostPageController = () => {
+  const [_, setChannel] = useLocalStorage("ViewChannelObj");
+  const { openModal, setModalView } = useUI();
+  const [channelName, setChannelName] = useState("");
+  const [tags, setTags] = useState<ITag[]>([]);
+
+  const navigate = useNavigate();
+
+  const tagWrapperRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    rootAPI.defaults.headers["Content-Type"] = "multipart/form-data";
+
+    return () => {
+      // initNewPostData();
+      rootAPI.defaults.headers["Content-Type"] =
+        "application/x-www-form-urlencoded";
+    };
+  }, []);
+
+  const mutation = useCreatePostMutation({ setChannel, notify, navigate });
+
+  const {
+    register,
+    handleSubmit,
+    setValue,
+    watch,
+    formState: {},
+  } = useForm<ICreatePostFormProps>();
+
+  const onValid = (data: ICreatePostFormProps) => {
+    // request body
+    //title: String, <- 필요한 데이터를 JSON.stringfy 해서 넣음
+    //image: Binary | null,
+    //channelId: String
+    const additionalData = JSON.stringify({
+      title: data.title,
+      content: data.content,
+      tags,
+    });
+
+    const postData: IPostBodyData = {
+      title: additionalData,
+      image: data.file,
+      channelId: data.channelId,
+    };
+
+    mutation.mutate(postData);
+  };
+  const onInvalid = (errors: FieldErrors) => {
+    console.log(errors);
+  };
+
+  const postFileClickHandler = (
+    event: React.MouseEvent<HTMLDivElement, MouseEvent>
+  ) => {
+    const nativeEvent = event.nativeEvent;
+
+    const objectWidth = tagWrapperRef.current?.offsetWidth;
+    const objectHeight = tagWrapperRef.current?.offsetHeight;
+
+    setModalView("TAG_CREATE_VIEW");
+    if (objectHeight && objectWidth) {
+      openModal({
+        x: (nativeEvent.offsetX / objectWidth) * 100,
+        y: (nativeEvent.offsetY / objectHeight) * 100,
+        tags,
+        setTags,
+      });
+    }
+  };
+
+  const tagClickHandler = (id: string, x?: number, y?: number) => {
+    setModalView("TAG_CREATE_VIEW");
+    openModal({
+      isEdit: true,
+      id: id,
+      x,
+      y,
+      tags,
+      setTags,
+    });
+  };
+
+  const channelSelectButtonClickHandler = () => {
+    setModalView("CHANNEL_SELECT_VIEW");
+    openModal({
+      setChannelId: (data: string) => setValue("channelId", data),
+      setChannelName: setChannelName,
+    });
+  };
+
+  return (
+    <CreatePostPageView
+      handleSubmit={handleSubmit}
+      onValid={onValid}
+      onInvalid={onInvalid}
+      setValue={setValue}
+      tagWrapperRef={tagWrapperRef}
+      postFileClickHandler={postFileClickHandler}
+      tags={tags}
+      tagClickHandler={tagClickHandler}
+      register={register}
+      channelSelectButtonClickHandler={channelSelectButtonClickHandler}
+      channelName={channelName}
+      watch={watch}
+      mutation={mutation}
+    />
+  );
+};
+
+export default CreatePostPageController;

--- a/src/pages/CreatePostPage/CreatePostPage.model.ts
+++ b/src/pages/CreatePostPage/CreatePostPage.model.ts
@@ -1,0 +1,41 @@
+import { useMutation } from "@tanstack/react-query";
+
+import { _POST } from "@/api";
+import { IToastProps } from "@/utils/toast";
+
+import { IPostBodyData } from "./CreatePostPage.controller";
+import { NavigateOptions, To } from "react-router-dom";
+
+interface IUseCreatePostMutationProps {
+  setChannel: Function;
+  notify: ({ type, text }: IToastProps) => void;
+  navigate: (to: To, options?: NavigateOptions | undefined) => void;
+}
+
+export const useCreatePostMutation = ({
+  setChannel,
+  notify,
+  navigate,
+}: IUseCreatePostMutationProps) => {
+  const mutation = useMutation({
+    mutationFn: async (formData: IPostBodyData) =>
+      await _POST("/posts/create", formData),
+    onSuccess: data => {
+      setChannel(JSON.stringify(data?.data.channel));
+      notify({
+        type: "success",
+        text: "포스트를 성공적으로 생성했어요!",
+      });
+      navigate("/home");
+    },
+    onError: data => {
+      notify({
+        type: "error",
+        text: "포스트 생성에 실패했어요!",
+      });
+      console.log("Error", data);
+    },
+  });
+
+  return mutation;
+};

--- a/src/pages/CreatePostPage/CreatePostPage.model.ts
+++ b/src/pages/CreatePostPage/CreatePostPage.model.ts
@@ -26,7 +26,7 @@ export const useCreatePostMutation = ({
         type: "success",
         text: "포스트를 성공적으로 생성했어요!",
       });
-      navigate("/home");
+      navigate(-1);
     },
     onError: data => {
       notify({

--- a/src/pages/CreatePostPage/CreatePostPage.model.ts
+++ b/src/pages/CreatePostPage/CreatePostPage.model.ts
@@ -4,12 +4,11 @@ import { _POST } from "@/api";
 import { IToastProps } from "@/utils/toast";
 
 import { IPostBodyData } from "./CreatePostPage.controller";
-import { NavigateOptions, To } from "react-router-dom";
 
 interface IUseCreatePostMutationProps {
   setChannel: Function;
   notify: ({ type, text }: IToastProps) => void;
-  navigate: (to: To, options?: NavigateOptions | undefined) => void;
+  navigate: (delta: number) => void;
 }
 
 export const useCreatePostMutation = ({

--- a/src/pages/CreatePostPage/CreatePostPage.view.tsx
+++ b/src/pages/CreatePostPage/CreatePostPage.view.tsx
@@ -6,11 +6,17 @@ import {
   UseFormSetValue,
   UseFormWatch,
 } from "react-hook-form";
+import { UseMutationResult } from "@tanstack/react-query";
+import { AxiosResponse } from "axios";
 
 import { ITag } from "@/types/post";
-
 import { Row } from "@/styles/GlobalStyle";
 import { Button, Input, Upload } from "@/components/common";
+
+import {
+  ICreatePostFormProps,
+  IPostBodyData,
+} from "./CreatePostPage.controller";
 import {
   ChannelTag,
   CreatePostPageContainer,
@@ -19,12 +25,6 @@ import {
   TextArea,
   UploadSection,
 } from "./CreatePostPage.styles";
-import {
-  ICreatePostFormProps,
-  IPostBodyData,
-} from "./CreatePostPage.controller";
-import { UseMutationResult } from "@tanstack/react-query";
-import { AxiosResponse } from "axios";
 
 interface ICreatePostPageViewProps {
   handleSubmit: UseFormHandleSubmit<ICreatePostFormProps, undefined>;

--- a/src/pages/CreatePostPage/index.ts
+++ b/src/pages/CreatePostPage/index.ts
@@ -1,1 +1,1 @@
-export { default } from "./CreatePostPage.view";
+export { default } from "./CreatePostPage.controller";

--- a/src/utils/toast.tsx
+++ b/src/utils/toast.tsx
@@ -2,7 +2,7 @@ import { ToastContainer, toast } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
 import { styled } from "styled-components";
 
-interface IToastProps {
+export interface IToastProps {
   text: string;
   type: "default" | "success" | "warning" | "error";
 }


### PR DESCRIPTION
## 📝작업 내용

MVC 소프트웨어 디자인 패턴의 세 가지 부분은 다음과 같이 설명할 수 있습니다.

1. 모델: 데이터와 비즈니스 로직을 관리합니다.
2. 뷰: 레이아웃과 화면을 처리합니다.
3. 컨트롤러: 모델과 뷰로 명령을 전달합니다.

간단한 MVC 패턴 적용 예시입니다. 컴포넌트는 크게

Component.model.ts
Component.controller.tsx
Component.view.tsx
그리고 
Components.styles.ts 
로 나눕니다.

### Component.model.ts 의 경우
model.ts 는 서버와 데이터를 주고 받는 로직에 해당하는 코드를 분리해내면 된다고 생각하시면 됩니다.
(query 난 mutation 등등)

### Component.controller.tsx 의 경우
컴포넌트의 상태/동작과 관련된 로직에 해당하는 코드를 분리해내면 된다고 생각하시면 됩니다.
또한 해당 컴포넌트의 분리된 로직들을 한 곳에 모으는 module 의 역할을 한다고 생각하시면 됩니다.

### Component.view.tsx 의 경우
이름에서 알 수 있듯 렌더링 코드가 이에 해당합니다.
렌더링에 필요한 함수나, 상태 등은 controller 를 통해  props 로 전달 받습니다.

이러한 컴포넌트는 index.ts 를 통해 외부로 export 됩니다.

pages 의 경우 pages 자체의 index.ts 가 있기 때문에
CreateNewPostPage.index -> export { default } from "./CreateNewPostPage.controller.tsx" 
와 같은 형식으로 export 합니다.
pages/index.ts 는
export { default as CreateNewPostPage } from "./CreateNewPostPage" 와 같은 형식으로 한번 더 export 해주게 되겠죠.

반면에 컴포넌트 단위에서 export 를 마무리한다면,
export { default as SomeComponent } from "./SomeComponent.controller.tsx" 
와 같은 형식으로 alias 를 주면 좋습니다.

자세한 사항은 코드를 참고하시면 쉽게 이해하실 수 있을 겁니다.
궁금하신 점이 있으시다면 부담없이 물어봐주세요!


### ✨스크린샷 (선택)

## 💬리뷰 요구사항(선택)

