### PR TITLE
[♻️refactor]: 홈 페이지와 상단 내비게이션 바를 제외한 웹 접근성, 웹 표준 사항 준수 업데이트

### DIFF
--- a/src/components/ButtonSet/index.tsx
+++ b/src/components/ButtonSet/index.tsx
@@ -7,6 +7,7 @@ export interface IButtonProps {
   items: Array<{
     name: string;
     size: number;
+    ariaString: string;
     color?: string | undefined;
     onClick: (e: React.MouseEvent<HTMLButtonElement>) => void;
   }>;
@@ -24,7 +25,11 @@ const ButtonSet = ({ items, style }: IButtonProps) => {
     <>
       {items.map((item, index) => (
         <ButtonWrap key={index.toString()}>
-          <Button {...style} onClick={item.onClick}>
+          <Button
+            {...style}
+            onClick={item.onClick}
+            aria-label={`${item.ariaString} 버튼`}
+          >
             <Icon name={item.name} size={item.size} color={item.color} />
           </Button>
         </ButtonWrap>

--- a/src/components/ButtonSet/index.tsx
+++ b/src/components/ButtonSet/index.tsx
@@ -21,7 +21,9 @@ const ButtonSet = ({ children, style }: IButtonProps) => {
         children.map((child, index) => {
           return (
             <ButtonWrap key={child + index.toString()}>
-              <Button {...style}>{child}</Button>
+              <Button tabIndex={-1} {...style}>
+                {child}
+              </Button>
             </ButtonWrap>
           );
         })

--- a/src/components/ButtonSet/index.tsx
+++ b/src/components/ButtonSet/index.tsx
@@ -1,10 +1,15 @@
 import { Button } from "@/components/common";
-import { ReactNode } from "react";
 import { styled } from "styled-components";
+import Icon from "../common/Icon/Icon";
 
 type TVariant = "flat" | "neumorp" | "symbol" | "disabled";
 export interface IButtonProps {
-  children: ReactNode[] | ReactNode;
+  items: Array<{
+    name: string;
+    size: number;
+    color?: string | undefined;
+    onClick: (e: React.MouseEvent<HTMLButtonElement>) => void;
+  }>;
   style: {
     variant: TVariant;
     width?: number;
@@ -14,24 +19,16 @@ export interface IButtonProps {
 
 const ButtonWrap = styled.div<{ key: string }>``;
 
-const ButtonSet = ({ children, style }: IButtonProps) => {
+const ButtonSet = ({ items, style }: IButtonProps) => {
   return (
     <>
-      {Array.isArray(children) ? (
-        children.map((child, index) => {
-          return (
-            <ButtonWrap key={child + index.toString()}>
-              <Button tabIndex={-1} {...style}>
-                {child}
-              </Button>
-            </ButtonWrap>
-          );
-        })
-      ) : (
-        <div>
-          <Button {...style}>{children}</Button>
-        </div>
-      )}
+      {items.map((item, index) => (
+        <ButtonWrap key={index.toString()}>
+          <Button {...style} onClick={item.onClick}>
+            <Icon name={item.name} size={item.size} color={item.color} />
+          </Button>
+        </ButtonWrap>
+      ))}
     </>
   );
 };

--- a/src/components/Chats/ChatLi/ChatLi.tsx
+++ b/src/components/Chats/ChatLi/ChatLi.tsx
@@ -37,7 +37,14 @@ const ChatLi = ({
         <Avatar size="M" src={senderProfile} />
         {senderIsOnline && <OnlineIndicator />}
       </ChatLiAvatarBox>
-      <ChatLiArticle>
+      <ChatLiArticle
+        tabIndex={0}
+        role="link"
+        aria-label={`${senderName}와의 채팅방으로 이동하기`}
+        onKeyDown={e => {
+          if (e.key === "Enter") onClickHandler(senderId);
+        }}
+      >
         <p>
           <strong>{senderName}</strong>
         </p>

--- a/src/components/Notification/NotificationCard/NotificationCard.tsx
+++ b/src/components/Notification/NotificationCard/NotificationCard.tsx
@@ -27,7 +27,7 @@ const NotificationCard = ({
   return (
     <CardWrapper>
       <div
-        role="button"
+        role="link"
         tabIndex={0}
         aria-label={`${data.author.fullName} 회원 페이지로 이동하기`}
         className="cursor-pointer"
@@ -44,7 +44,7 @@ const NotificationCard = ({
         onKeyDown={e => {
           if (e.key === "Enter") onClickHandler(data);
         }}
-        role="button"
+        role="link"
         tabIndex={0}
         aria-label={`${data.author.fullName} 해당 게시글 및 회원 페이지로 이동하기`}
       >

--- a/src/components/Notification/NotificationCard/NotificationCard.tsx
+++ b/src/components/Notification/NotificationCard/NotificationCard.tsx
@@ -27,14 +27,26 @@ const NotificationCard = ({
   return (
     <CardWrapper>
       <div
+        role="button"
+        tabIndex={0}
+        aria-label={`${data.author.fullName} 회원 페이지로 이동하기`}
         className="cursor-pointer"
         onClick={() => onClickHandler(data, true)}
+        onKeyDown={e => {
+          if (e.key === "Enter") onClickHandler(data, true);
+        }}
       >
         <Avatar size="S" src={data.author.image} />
       </div>
       <article
         className="flex-1 flex flex-col justify-center"
         onClick={() => onClickHandler(data)}
+        onKeyDown={e => {
+          if (e.key === "Enter") onClickHandler(data);
+        }}
+        role="button"
+        tabIndex={0}
+        aria-label={`${data.author.fullName} 해당 게시글 및 회원 페이지로 이동하기`}
       >
         <p className="cursor-pointer">
           <strong>{data.author.fullName}</strong>님이 {CONTENT[type]}

--- a/src/components/SearchTab/index.tsx
+++ b/src/components/SearchTab/index.tsx
@@ -35,6 +35,7 @@ const SearchTab = ({ option = "user", onClick, ...props }: ISearchTab) => {
           pointerEvents: tab === "user" ? "none" : undefined,
         }}
         onClickHandler={() => onClickTab()}
+        aria-label="검색된 사용자 보기"
       >
         사용자
       </Button>
@@ -48,6 +49,7 @@ const SearchTab = ({ option = "user", onClick, ...props }: ISearchTab) => {
           pointerEvents: tab === "post" ? "none" : undefined,
         }}
         onClickHandler={() => onClickTab()}
+        aria-label="검색된 게시글 보기"
       >
         게시글
       </Button>

--- a/src/components/common/Icon/Icon.tsx
+++ b/src/components/common/Icon/Icon.tsx
@@ -15,6 +15,7 @@ export interface IIconProps {
   weight?: number;
   className?: string;
   onClick?: React.MouseEventHandler<HTMLElement>;
+  onKeyDown?: React.KeyboardEventHandler<HTMLElement>;
 }
 
 export interface IIconStyle {

--- a/src/components/common/Icon/Icon.tsx
+++ b/src/components/common/Icon/Icon.tsx
@@ -49,6 +49,7 @@ const Icon = ({
 
   return (
     <i
+      tabIndex={0}
       className={`material-symbols-rounded ${className}`}
       style={iconStyle}
       {...props}

--- a/src/components/common/Icon/Icon.tsx
+++ b/src/components/common/Icon/Icon.tsx
@@ -15,7 +15,6 @@ export interface IIconProps {
   weight?: number;
   className?: string;
   onClick?: React.MouseEventHandler<HTMLElement>;
-  onKeyDown?: React.KeyboardEventHandler<HTMLElement>;
 }
 
 export interface IIconStyle {
@@ -50,7 +49,6 @@ const Icon = ({
 
   return (
     <i
-      tabIndex={0}
       className={`material-symbols-rounded ${className}`}
       style={iconStyle}
       {...props}

--- a/src/components/common/Navigator/BottomNavBar/BottomNavBar.tsx
+++ b/src/components/common/Navigator/BottomNavBar/BottomNavBar.tsx
@@ -93,6 +93,7 @@ const BottomNavBar = () => {
           useRipple={true}
           onClickHandler={() => handleIconClick(PathName.HOME)}
           style={ButtonChildrenSortingStyle}
+          aria-label="홈 화면으로 가기"
         >
           {
             <Icon
@@ -109,6 +110,7 @@ const BottomNavBar = () => {
           useRipple={true}
           onClickHandler={() => handleIconClick(PathName.SEARCH)}
           style={ButtonChildrenSortingStyle}
+          aria-label="검색 화면으로 가기"
         >
           {
             <Icon
@@ -126,6 +128,7 @@ const BottomNavBar = () => {
             useRipple={true}
             onClickHandler={() => handleIconClick(PathName.NEWPOST)}
             style={ButtonChildrenSortingStyle}
+            aria-label="포스팅 생성 화면으로 가기"
           >
             {
               <Icon
@@ -145,6 +148,7 @@ const BottomNavBar = () => {
           useRipple={true}
           onClickHandler={() => handleIconClick(PathName.CHANNELS)}
           style={ButtonChildrenSortingStyle}
+          aria-label="채널 선택 화면으로 가기"
         >
           {
             <Icon
@@ -167,6 +171,7 @@ const BottomNavBar = () => {
               : () => handleIconClick(`login`)
           }
           style={ButtonChildrenSortingStyle}
+          aria-label={id ? `내 프로필 화면으로 가기` : `로그인 화면으로 가기`}
         >
           {id ? (
             <Avatar size="XS" src={profilePhoto ? profilePhoto : ""} />

--- a/src/components/common/PostSimpleCard/PostSimpleCard.styles.ts
+++ b/src/components/common/PostSimpleCard/PostSimpleCard.styles.ts
@@ -1,7 +1,7 @@
 import { Row } from "@/styles/GlobalStyle";
 import styled, { css, keyframes } from "styled-components";
 
-export const CardContainer = styled.div<{ $basis: "half" | "full" }>`
+export const CardContainer = styled.article<{ $basis: "half" | "full" }>`
   /* 기본 */
   font-size: 1rem;
   flex-direction: column;

--- a/src/components/common/PostSimpleCard/PostSimpleCard.tsx
+++ b/src/components/common/PostSimpleCard/PostSimpleCard.tsx
@@ -235,10 +235,23 @@ const PostSimpleCard = ({
     );
   }
 
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLElement>) => {
+    if (event.key === "Enter") {
+      onClickImage();
+    }
+  };
+
+  console.log(postData);
+
   if (mutation.isSuccess) {
     return (
       <>
-        <CardContainer $basis="half">
+        <CardContainer
+          tabIndex={0}
+          aria-label={`${JSON.parse(postData.title).title}게시물 보기`}
+          onKeyDown={event => handleKeyDown(event)}
+          $basis="half"
+        >
           <CardImageContainer style={{ minHeight: "200px", minWidth: "100%" }}>
             {/* todo, 카드 컴포넌트 원주님과 협업 후 공용 컴포넌트로 변경 */}
             <CardImage

--- a/src/components/common/PostSimpleCard/PostSimpleCard.tsx
+++ b/src/components/common/PostSimpleCard/PostSimpleCard.tsx
@@ -241,8 +241,6 @@ const PostSimpleCard = ({
     }
   };
 
-  console.log(postData);
-
   if (mutation.isSuccess) {
     return (
       <>

--- a/src/components/common/PostSimpleCard/PostSimpleCard.tsx
+++ b/src/components/common/PostSimpleCard/PostSimpleCard.tsx
@@ -246,7 +246,7 @@ const PostSimpleCard = ({
       <>
         <CardContainer
           tabIndex={0}
-          aria-label={`${JSON.parse(postData.title).title}게시물 보기`}
+          aria-label={`${JSON.parse(postData.title).title} 게시물 보기`}
           onKeyDown={event => handleKeyDown(event)}
           $basis="half"
         >

--- a/src/pages/ChannelsPage/ChannelsPage.styles.ts
+++ b/src/pages/ChannelsPage/ChannelsPage.styles.ts
@@ -1,6 +1,6 @@
 import styled from "styled-components";
 
-export const ContainDiv = styled.div`
+export const ContainSection = styled.section`
   padding-bottom: 3rem;
   box-sizing: border-box;
 `;

--- a/src/pages/ChannelsPage/ChannelsPage.view.tsx
+++ b/src/pages/ChannelsPage/ChannelsPage.view.tsx
@@ -2,7 +2,7 @@ import { _GET } from "@/api";
 import { useLocalStorage } from "@/hooks/useLocalStorage";
 import { useQuery } from "@tanstack/react-query";
 import { useNavigate } from "react-router-dom";
-import { ChannelStyle, ContainDiv } from "./ChannelsPage.styles";
+import { ChannelStyle, ContainSection } from "./ChannelsPage.styles";
 import { GET_CHANNELS } from "@/constants/queryKey";
 import { Button } from "@/components/common";
 
@@ -23,7 +23,7 @@ const ChannelsPage = () => {
   if (data?.data) {
     return (
       <>
-        <ContainDiv>
+        <ContainSection>
           {data?.data.map((val: any) => {
             return (
               <ChannelStyle key={val._id}>
@@ -37,7 +37,7 @@ const ChannelsPage = () => {
               </ChannelStyle>
             );
           })}
-        </ContainDiv>
+        </ContainSection>
       </>
     );
   }

--- a/src/pages/ChannelsPage/ChannelsPage.view.tsx
+++ b/src/pages/ChannelsPage/ChannelsPage.view.tsx
@@ -27,7 +27,11 @@ const ChannelsPage = () => {
           {data?.data.map((val: any) => {
             return (
               <ChannelStyle key={val._id}>
-                <Button variant="neumorp" onClick={() => handleClick(val)}>
+                <Button
+                  variant="neumorp"
+                  onClick={() => handleClick(val)}
+                  aria-label={`${val.name} 채널으로 이동하기`}
+                >
                   {val.name}
                 </Button>
               </ChannelStyle>

--- a/src/pages/HomePage/HomePage.tsx
+++ b/src/pages/HomePage/HomePage.tsx
@@ -12,7 +12,7 @@ import { useMe } from "@/hooks/useMe";
 import { Spinner } from "@/components/common/Spinner";
 const { VITE_ADMIN_ID } = import.meta.env;
 
-const Container = styled.div`
+const Container = styled.section`
   box-sizing: border-box;
   display: flex;
   flex-direction: row;

--- a/src/pages/LoginPage/LoginPageView.tsx
+++ b/src/pages/LoginPage/LoginPageView.tsx
@@ -109,6 +109,7 @@ const LoginPageView = () => {
         </ErrorContainer>
         <InputContainer
           type="text"
+          aria-required="true"
           placeholder="looky@example.com"
           {...register("email", LoginPageConst.EMAIL_VALIDATION_OPTION)}
         />
@@ -130,7 +131,6 @@ const LoginPageView = () => {
 
         <LogInButtonContainer
           aria-label="로그인 요청 버튼"
-          aria-required="true"
           onSubmit={handleSubmit(onValid, onInValid)}
         >
           로그인

--- a/src/pages/LoginPage/LoginPageView.tsx
+++ b/src/pages/LoginPage/LoginPageView.tsx
@@ -127,12 +127,19 @@ const LoginPageView = () => {
           {...register("password", LoginPageConst.PASSWORD_VALIDATION_OPTION)}
         />
 
-        <LogInButtonContainer onSubmit={handleSubmit(onValid, onInValid)}>
+        <LogInButtonContainer
+          aria-label="로그인 요청 버튼"
+          onSubmit={handleSubmit(onValid, onInValid)}
+        >
           로그인
         </LogInButtonContainer>
       </FormContainer>
-      <SignInLinkContainer to="/signin">회원가입</SignInLinkContainer>
-      <DoNotLoginLink to="/home">로그인 하지 않고 이용하기</DoNotLoginLink>
+      <SignInLinkContainer aria-label="회원가입 페이지 전환 버튼" to="/signin">
+        회원가입
+      </SignInLinkContainer>
+      <DoNotLoginLink aria-label="로그인 하지 않고 사용하기 버튼" to="/home">
+        로그인 하지 않고 이용하기
+      </DoNotLoginLink>
     </LogInPageContainer>
   );
 };

--- a/src/pages/LoginPage/LoginPageView.tsx
+++ b/src/pages/LoginPage/LoginPageView.tsx
@@ -123,12 +123,14 @@ const LoginPageView = () => {
         </ErrorContainer>
         <InputContainer
           type="password"
+          aria-required="true"
           placeholder="비밀번호"
           {...register("password", LoginPageConst.PASSWORD_VALIDATION_OPTION)}
         />
 
         <LogInButtonContainer
           aria-label="로그인 요청 버튼"
+          aria-required="true"
           onSubmit={handleSubmit(onValid, onInValid)}
         >
           로그인

--- a/src/pages/ProfilePage/ProfilePage.style.tsx
+++ b/src/pages/ProfilePage/ProfilePage.style.tsx
@@ -6,9 +6,13 @@ import {
 import { Col, Row } from "@/styles/GlobalStyle";
 import { css, styled } from "styled-components";
 
-export const Profile = styled(Col)<{ $isMe: string; $coverImage: string }>`
+export const Profile = styled.section<{ $isMe: string; $coverImage: string }>`
+  display: flex;
+  flex-direction: column;
+  position: relative;
   min-height: calc(100vh - ${NAV_HEIGHT * 2}rem - 10px);
   height: calc(100vh - ${NAV_HEIGHT * 2}rem - 10px);
+  width: 100%;
   border-top-left-radius: 0.375rem;
   border-top-right-radius: 0.375rem;
   padding: 1rem;
@@ -52,7 +56,9 @@ export const InfoWrap = styled(Col)`
   margin-bottom: 1rem;
 `;
 
-export const Posts = styled(Col)`
+export const Posts = styled.section`
+  display: flex;
+  flex-direction: column;
   justify-content: flex-start;
   align-items: center;
   min-height: 576px;
@@ -95,4 +101,12 @@ export const Container = styled.div`
 export const EmptyPost = styled.div`
   flex-grow: 1;
   justify-content: center;
+`;
+
+export const CoverChange = styled.button`
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
 `;

--- a/src/pages/ProfilePage/Views/ProfileView.tsx
+++ b/src/pages/ProfilePage/Views/ProfileView.tsx
@@ -167,7 +167,9 @@ const ProfileView = ({
     },
   });
 
-  const handleClickFollow = (e: React.MouseEvent) => {
+  const handleClickFollow = <T extends React.MouseEvent | React.KeyboardEvent>(
+    e: T
+  ) => {
     e.stopPropagation();
     if (userId === undefined) return;
 
@@ -178,44 +180,86 @@ const ProfileView = ({
     }
   };
 
-  const onKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === "Enter") {
-      onClickCover(e as unknown as React.MouseEvent);
-    }
-  };
-
   return (
     // div태그이므로 alt 태그 추가 불가
     <Profile
       $isMe={isMe.toString()}
       tabIndex={0}
       $coverImage={isMe ? profileCover : userCover ?? ""}
+      // 여기서 발생하는 버블링을 캐치하지 못하는 중..
       onClick={e => {
-        isMe ? onClickCover(e) : null;
+        if (e.type === "click" && e.button === 0 && isMe) {
+          onClickCover(e);
+        }
       }}
-      onKeyDown={onKeyDown}
+      onKeyDown={e => {
+        if (e.key === "Enter") {
+          if (isMe) {
+            onClickCover(e);
+          }
+        }
+      }}
     >
+      {/* 기존 마우스 이벤트가 버튼이 아닌 아이콘에 있는 문제 있음 */}
+      {/* 따라서 아이콘 뎁스까지 들어가지 않아서 키보드 이벤트로 접근할 수 없는 문제점 발생 */}
       {isMe && (
         <ButtonsWrap className="me">
           <ButtonSet style={buttonStyle}>
             <Icon
               name="Password"
               size={ICON_SIZE_SMALL}
-              onClick={onClickPassword}
+              onClick={e => {
+                console.log(`?`);
+                if (isMe) {
+                  e.stopPropagation();
+                  onClickPassword(e);
+                }
+              }}
+              onKeyDown={e => {
+                console.log(`?`);
+                if (e.key === "Enter") {
+                  console.log(`?`);
+                  onClickPassword(e);
+                  e.stopPropagation();
+                }
+              }}
             />
             <Icon
               name="logout"
               size={ICON_SIZE_SMALL}
-              onClick={onClickLogout}
+              onClick={e => {
+                e.stopPropagation();
+                onClickLogout(e);
+              }}
+              onKeyDown={e => {
+                if (e.key === "Enter") {
+                  if (isMe) {
+                    e.stopPropagation();
+                    onClickLogout(e);
+                  }
+                }
+              }}
             />
           </ButtonSet>
         </ButtonsWrap>
       )}
       <InfoWrap {...props}>
         <AvatarWrap
+          tabIndex={0}
           $isMe={isMe.toString()}
           onClick={e => {
-            isMe ? onClickAvatar(e) : null;
+            if (isMe) {
+              e.stopPropagation();
+              onClickAvatar(e);
+            }
+          }}
+          onKeyDown={e => {
+            if (e.key === "Enter") {
+              if (isMe) {
+                e.stopPropagation();
+                onClickAvatar(e);
+              }
+            }
           }}
         >
           <Avatar src={isMe ? profileImage : userImage ?? ""} size="XL" />
@@ -229,6 +273,7 @@ const ProfileView = ({
         {isMe && (
           <ButtonsWrap className="me">
             <Button
+              tabIndex={-1}
               width={ICON_SIZE_SMALL}
               variant="neumorp"
               style={{
@@ -241,6 +286,12 @@ const ProfileView = ({
                 color={theme.background_color}
                 size={ICON_SIZE_SMALL}
                 onClick={onClickEdit}
+                onKeyDown={e => {
+                  if (e.key === "Enter") {
+                    e.stopPropagation();
+                    onClickEdit(e);
+                  }
+                }}
               />
             </Button>
           </ButtonsWrap>
@@ -248,11 +299,25 @@ const ProfileView = ({
         {!isMe && (
           <ButtonsWrap className="others">
             <ButtonSet style={buttonStyle}>
-              <Icon name="chat_bubble" onClick={e => onClickChat(e, userId)} />
+              {/* link 태그로 바꿔야함 */}
+              <Icon
+                name="chat_bubble"
+                onClick={e => onClickChat(e, userId)}
+                onKeyDown={e => {
+                  if (e.key === "Enter") {
+                    onClickChat(e, userId);
+                  }
+                }}
+              />
               <Icon
                 name={!isFollow ? "person_add" : "person_check"}
                 color={isFollow ? theme.symbol_color : undefined}
                 onClick={handleClickFollow}
+                onKeyDown={e => {
+                  if (e.key === "Enter") {
+                    handleClickFollow(e);
+                  }
+                }}
               />
             </ButtonSet>
           </ButtonsWrap>

--- a/src/pages/ProfilePage/Views/ProfileView.tsx
+++ b/src/pages/ProfilePage/Views/ProfileView.tsx
@@ -7,6 +7,7 @@ import { ButtonSet } from "@/components";
 import {
   AvatarWrap,
   ButtonsWrap,
+  CoverChange,
   InfoWrap,
   Profile,
 } from "../ProfilePage.style";
@@ -192,11 +193,13 @@ const ProfileView = ({
       name: "Password",
       size: ICON_SIZE_SMALL,
       onClick: onClickPassword,
+      ariaString: "패스워드 변경하기",
     },
     {
       name: "logout",
       size: ICON_SIZE_SMALL,
       onClick: onClickLogout,
+      ariaString: "로그아웃 하기",
     },
   ];
 
@@ -205,12 +208,16 @@ const ProfileView = ({
       name: "chat_bubble",
       size: ICON_SIZE_SMALL,
       onClick: handleClickChat,
+      ariaString: `${profileName} 회원과 채팅하기`,
     },
     {
       name: !isFollow ? "person_add" : "person_check",
       size: ICON_SIZE_SMALL,
       color: isFollow ? theme.symbol_color : undefined,
       onClick: handleClickFollow,
+      ariaString: !isFollow
+        ? `${profileName} 회원 팔로우하기`
+        : `${profileName} 회원 팔로우 취소하기`,
     },
   ];
 
@@ -218,28 +225,18 @@ const ProfileView = ({
     <Profile
       $isMe={isMe.toString()}
       $coverImage={isMe ? profileCover : userCover ?? ""}
-      // 여기서 발생하는 버블링을 캐치하지 못하는 중..
-      // 생각되는 문제점 -> div라서..?
-      onClick={e => {
-        console.log(`active!`);
-        e.stopPropagation();
-        if (e.type === "click" && e.button === 0 && isMe) {
-          console.log(`active!2`);
-          onClickCover(e);
-        }
-      }}
-      onKeyDown={e => {
-        console.log(e);
-        e.stopPropagation();
-        console.log(`active! 3`);
-        if (e.key === "Enter") {
-          console.log(`active! 4`);
-          if (isMe) {
-            onClickCover(e);
-          }
-        }
-      }}
     >
+      {isMe && (
+        <CoverChange
+          onClick={e => {
+            e.stopPropagation();
+            if (e.type === "click" && isMe) {
+              onClickCover(e);
+            }
+          }}
+          aria-label="커버 이미지 변경하기"
+        />
+      )}
       {isMe && (
         <ButtonsWrap className="me">
           <ButtonSet style={buttonStyle} items={passwordAndLogoutItems} />

--- a/src/pages/ProfilePage/Views/ProfileView.tsx
+++ b/src/pages/ProfilePage/Views/ProfileView.tsx
@@ -23,12 +23,23 @@ import { notify } from "@/utils/toast";
 
 interface IProfileProps {
   userInfo: IUser;
-  onClickLogout: (e: React.MouseEvent) => void;
-  onClickPassword: (e: React.MouseEvent) => void;
-  onClickEdit: (e: React.MouseEvent) => void;
-  onClickAvatar: (e: React.MouseEvent) => void;
-  onClickCover: (e: React.MouseEvent) => void;
-  onClickChat: (e: React.MouseEvent, paramsId: string) => void;
+  onClickLogout: <T extends React.MouseEvent | React.KeyboardEvent>(
+    e: T
+  ) => void;
+  onClickPassword: <T extends React.MouseEvent | React.KeyboardEvent>(
+    e: T
+  ) => void;
+  onClickEdit: <T extends React.MouseEvent | React.KeyboardEvent>(e: T) => void;
+  onClickAvatar: <T extends React.MouseEvent | React.KeyboardEvent>(
+    e: T
+  ) => void;
+  onClickCover: <T extends React.MouseEvent | React.KeyboardEvent>(
+    e: T
+  ) => void;
+  onClickChat: <T extends React.MouseEvent | React.KeyboardEvent>(
+    e: T,
+    paramsId: string
+  ) => void;
   [key: string]: any;
 }
 

--- a/src/pages/ProfilePage/Views/ProfileView.tsx
+++ b/src/pages/ProfilePage/Views/ProfileView.tsx
@@ -180,6 +180,40 @@ const ProfileView = ({
     }
   };
 
+  const handleClickChat = <T extends React.MouseEvent | React.KeyboardEvent>(
+    e: T
+  ) => {
+    e.stopPropagation();
+    if (userId) onClickChat(e, userId);
+  };
+
+  const passwordAndLogoutItems = [
+    {
+      name: "Password",
+      size: ICON_SIZE_SMALL,
+      onClick: onClickPassword,
+    },
+    {
+      name: "logout",
+      size: ICON_SIZE_SMALL,
+      onClick: onClickLogout,
+    },
+  ];
+
+  const followAndMessage = [
+    {
+      name: "chat_bubble",
+      size: ICON_SIZE_SMALL,
+      onClick: handleClickChat,
+    },
+    {
+      name: !isFollow ? "person_add" : "person_check",
+      size: ICON_SIZE_SMALL,
+      color: isFollow ? theme.symbol_color : undefined,
+      onClick: handleClickFollow,
+    },
+  ];
+
   return (
     // div태그이므로 alt 태그 추가 불가
     <Profile

--- a/src/pages/ProfilePage/Views/ProfileView.tsx
+++ b/src/pages/ProfilePage/Views/ProfileView.tsx
@@ -217,17 +217,29 @@ const ProfileView = ({
   return (
     <Profile
       $isMe={isMe.toString()}
-      tabIndex={0}
       $coverImage={isMe ? profileCover : userCover ?? ""}
       // 여기서 발생하는 버블링을 캐치하지 못하는 중..
+      // 생각되는 문제점 -> div라서..?
       onClick={e => {
+        console.log(`active!`);
+        e.stopPropagation();
         if (e.type === "click" && e.button === 0 && isMe) {
+          console.log(`active!2`);
           onClickCover(e);
         }
       }}
+      onKeyDown={e => {
+        console.log(e);
+        e.stopPropagation();
+        console.log(`active! 3`);
+        if (e.key === "Enter") {
+          console.log(`active! 4`);
+          if (isMe) {
+            onClickCover(e);
+          }
+        }
+      }}
     >
-      {/* 기존 마우스 이벤트가 버튼이 아닌 아이콘에 있는 문제 있음 */}
-      {/* 따라서 아이콘 뎁스까지 들어가지 않아서 키보드 이벤트로 접근할 수 없는 문제점 발생 */}
       {isMe && (
         <ButtonsWrap className="me">
           <ButtonSet style={buttonStyle} items={passwordAndLogoutItems} />

--- a/src/pages/ProfilePage/Views/ProfileView.tsx
+++ b/src/pages/ProfilePage/Views/ProfileView.tsx
@@ -167,7 +167,14 @@ const ProfileView = ({
     }
   };
 
+  const onKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter") {
+      onClickCover(e as unknown as React.MouseEvent);
+    }
+  };
+
   return (
+    // div태그이므로 alt 태그 추가 불가
     <Profile
       $isMe={isMe.toString()}
       tabIndex={0}
@@ -175,6 +182,7 @@ const ProfileView = ({
       onClick={e => {
         isMe ? onClickCover(e) : null;
       }}
+      onKeyDown={onKeyDown}
     >
       {isMe && (
         <ButtonsWrap className="me">

--- a/src/pages/ProfilePage/Views/ProfileView.tsx
+++ b/src/pages/ProfilePage/Views/ProfileView.tsx
@@ -215,7 +215,6 @@ const ProfileView = ({
   ];
 
   return (
-    // div태그이므로 alt 태그 추가 불가
     <Profile
       $isMe={isMe.toString()}
       tabIndex={0}
@@ -226,71 +225,28 @@ const ProfileView = ({
           onClickCover(e);
         }
       }}
-      onKeyDown={e => {
-        if (e.key === "Enter") {
-          if (isMe) {
-            onClickCover(e);
-          }
-        }
-      }}
     >
       {/* 기존 마우스 이벤트가 버튼이 아닌 아이콘에 있는 문제 있음 */}
       {/* 따라서 아이콘 뎁스까지 들어가지 않아서 키보드 이벤트로 접근할 수 없는 문제점 발생 */}
       {isMe && (
         <ButtonsWrap className="me">
-          <ButtonSet style={buttonStyle}>
-            <Icon
-              name="Password"
-              size={ICON_SIZE_SMALL}
-              onClick={e => {
-                console.log(`?`);
-                if (isMe) {
-                  e.stopPropagation();
-                  onClickPassword(e);
-                }
-              }}
-              onKeyDown={e => {
-                console.log(`?`);
-                if (e.key === "Enter") {
-                  console.log(`?`);
-                  onClickPassword(e);
-                  e.stopPropagation();
-                }
-              }}
-            />
-            <Icon
-              name="logout"
-              size={ICON_SIZE_SMALL}
-              onClick={e => {
-                e.stopPropagation();
-                onClickLogout(e);
-              }}
-              onKeyDown={e => {
-                if (e.key === "Enter") {
-                  if (isMe) {
-                    e.stopPropagation();
-                    onClickLogout(e);
-                  }
-                }
-              }}
-            />
-          </ButtonSet>
+          <ButtonSet style={buttonStyle} items={passwordAndLogoutItems} />
         </ButtonsWrap>
       )}
       <InfoWrap {...props}>
         <AvatarWrap
-          tabIndex={0}
+          tabIndex={isMe ? 0 : -1}
           $isMe={isMe.toString()}
           onClick={e => {
+            e.stopPropagation();
             if (isMe) {
-              e.stopPropagation();
               onClickAvatar(e);
             }
           }}
           onKeyDown={e => {
             if (e.key === "Enter") {
+              e.stopPropagation();
               if (isMe) {
-                e.stopPropagation();
                 onClickAvatar(e);
               }
             }
@@ -307,53 +263,25 @@ const ProfileView = ({
         {isMe && (
           <ButtonsWrap className="me">
             <Button
-              tabIndex={-1}
               width={ICON_SIZE_SMALL}
               variant="neumorp"
               style={{
                 height: ICON_SIZE_SMALL,
                 borderRadius: ICON_SIZE_SMALL / 2,
               }}
+              onClick={onClickEdit}
             >
               <Icon
                 name="Edit"
                 color={theme.background_color}
                 size={ICON_SIZE_SMALL}
-                onClick={onClickEdit}
-                onKeyDown={e => {
-                  if (e.key === "Enter") {
-                    e.stopPropagation();
-                    onClickEdit(e);
-                  }
-                }}
               />
             </Button>
           </ButtonsWrap>
         )}
         {!isMe && (
           <ButtonsWrap className="others">
-            <ButtonSet style={buttonStyle}>
-              {/* link 태그로 바꿔야함 */}
-              <Icon
-                name="chat_bubble"
-                onClick={e => onClickChat(e, userId)}
-                onKeyDown={e => {
-                  if (e.key === "Enter") {
-                    onClickChat(e, userId);
-                  }
-                }}
-              />
-              <Icon
-                name={!isFollow ? "person_add" : "person_check"}
-                color={isFollow ? theme.symbol_color : undefined}
-                onClick={handleClickFollow}
-                onKeyDown={e => {
-                  if (e.key === "Enter") {
-                    handleClickFollow(e);
-                  }
-                }}
-              />
-            </ButtonSet>
+            <ButtonSet style={buttonStyle} items={followAndMessage} />
           </ButtonsWrap>
         )}
       </InfoWrap>

--- a/src/pages/ProfilePage/Views/ProfileView.tsx
+++ b/src/pages/ProfilePage/Views/ProfileView.tsx
@@ -170,6 +170,7 @@ const ProfileView = ({
   return (
     <Profile
       $isMe={isMe.toString()}
+      tabIndex={0}
       $coverImage={isMe ? profileCover : userCover ?? ""}
       onClick={e => {
         isMe ? onClickCover(e) : null;

--- a/src/pages/ProfilePage/index.tsx
+++ b/src/pages/ProfilePage/index.tsx
@@ -58,35 +58,51 @@ const ProfilePage = () => {
     updateUserData();
   }, [paramsId]);
 
-  const handleChangePassword = (e: React.MouseEvent) => {
+  const handleChangePassword = <
+    T extends React.MouseEvent | React.KeyboardEvent,
+  >(
+    e: T
+  ) => {
     e.stopPropagation();
     setModalView("EDIT_PASSWORD_VIEW");
     openModal();
   };
 
-  const handleChangeName = (e: React.MouseEvent) => {
+  const handleChangeName = <T extends React.MouseEvent | React.KeyboardEvent>(
+    e: T
+  ) => {
     e.stopPropagation();
     setModalView("EDIT_NAME_VIEW");
     openModal();
   };
 
-  const handleChangeImage = (e: React.MouseEvent) => {
+  const handleChangeImage = <T extends React.MouseEvent | React.KeyboardEvent>(
+    e: T
+  ) => {
     e.stopPropagation();
     setModalView("EDIT_IMAGE_VIEW");
     openModal();
   };
 
-  const handleChangeCover = () => {
+  const handleChangeCover = <T extends React.MouseEvent | React.KeyboardEvent>(
+    e: T
+  ) => {
+    e.stopPropagation();
     setModalView("EDIT_COVERIMAGE_VIEW");
     openModal();
   };
 
-  const handleClickChat = (e: React.MouseEvent, id: string) => {
+  const handleClickChat = <T extends React.MouseEvent | React.KeyboardEvent>(
+    e: T,
+    id: string
+  ) => {
     e.stopPropagation();
     navigate(`/chat/${id}`);
   };
 
-  const handleLogout = (e: React.MouseEvent) => {
+  const handleLogout = <T extends React.MouseEvent | React.KeyboardEvent>(
+    e: T
+  ) => {
     e.stopPropagation();
     const isLogout = confirm("로그아웃을 하시겠습니까?");
     if (isLogout) {

--- a/src/pages/SearchPage/SearchBar.tsx
+++ b/src/pages/SearchPage/SearchBar.tsx
@@ -56,6 +56,7 @@ const SearchBar = ({ onSearch, onClickBack }: ISearchBar) => {
         <Input
           className="shadow"
           type="text"
+          aria-required="true"
           onKeyDown={handleKeyDown}
           placeholder="검색어를 입력하세요. ex) 캐주얼"
           {...register("searchQuery", SEARCH_VALIDATION_OPTION)}

--- a/src/pages/SearchPage/Views/SearchEmptyView.tsx
+++ b/src/pages/SearchPage/Views/SearchEmptyView.tsx
@@ -6,10 +6,24 @@ interface SearchEmptyProps {
 }
 
 const SearchEmptyView = ({ children, onTagClick }: SearchEmptyProps) => {
+  const handleClick = (clickedKeyword: string | null) => {
+    if (clickedKeyword) {
+      onTagClick(clickedKeyword);
+    }
+  };
+
   const onClick = (e: React.MouseEvent) => {
     const target = e.target as HTMLDivElement;
     const clickedKeyword = target?.textContent;
-    clickedKeyword && onTagClick(clickedKeyword);
+    handleClick(clickedKeyword);
+  };
+
+  const onKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter") {
+      const target = e.target as HTMLDivElement;
+      const clickedKeyword = target?.textContent;
+      handleClick(clickedKeyword);
+    }
   };
 
   return (
@@ -18,7 +32,9 @@ const SearchEmptyView = ({ children, onTagClick }: SearchEmptyProps) => {
         <Text>{children}</Text>
         <Text>다음의 키워드를 검색해 보세요</Text>
         <TagWrap>
-          <Tag onClick={onClick}>캐주얼</Tag>
+          <Tag tabIndex={0} onClick={onClick} onKeyDown={onKeyDown}>
+            캐주얼
+          </Tag>
         </TagWrap>
       </Wrapper>
     </>

--- a/src/pages/SearchPage/Views/SearchEmptyView.tsx
+++ b/src/pages/SearchPage/Views/SearchEmptyView.tsx
@@ -32,7 +32,13 @@ const SearchEmptyView = ({ children, onTagClick }: SearchEmptyProps) => {
         <Text>{children}</Text>
         <Text>다음의 키워드를 검색해 보세요</Text>
         <TagWrap>
-          <Tag tabIndex={0} onClick={onClick} onKeyDown={onKeyDown}>
+          <Tag
+            role="button"
+            tabIndex={0}
+            aria-label="키워드 예시, 캐주얼 검색해보기"
+            onClick={onClick}
+            onKeyDown={onKeyDown}
+          >
             캐주얼
           </Tag>
         </TagWrap>

--- a/src/pages/SearchPage/Views/SearchRecentView.tsx
+++ b/src/pages/SearchPage/Views/SearchRecentView.tsx
@@ -25,6 +25,15 @@ const SearchRecentView = ({
     return [];
   }, [recentKeywords]);
 
+  const handleKeyDown = (
+    event: React.KeyboardEvent<HTMLElement>,
+    item: string
+  ) => {
+    if (event.key === "Enter") {
+      onItemClick(item);
+    }
+  };
+
   return (
     <section>
       <p
@@ -40,8 +49,11 @@ const SearchRecentView = ({
         {reversedKeywords && reversedKeywords.length > 0 ? (
           reversedKeywords.map((item, index) => (
             <LiContainer
+              tabIndex={0}
+              aria-label={`최근 검색어 ${item}으로 검색`}
               key={item.toString().concat(index)}
               onClick={() => onItemClick(item)}
+              onKeyDown={event => handleKeyDown(event, item)}
               {...props}
             >
               {item}

--- a/src/pages/SearchPage/Views/SearchUsersView.tsx
+++ b/src/pages/SearchPage/Views/SearchUsersView.tsx
@@ -39,7 +39,9 @@ const SearchUsersView = ({
           usersData.map(user => (
             <ListItem
               key={user._id}
+              role="link"
               tabIndex={0}
+              aria-label={`${user.fullName} 프로필 화면으로 이동하기`}
               onClick={() => onClick(user._id)}
               onKeyDown={event => handleKeyDown(event, user._id)}
               {...props}

--- a/src/pages/SearchPage/Views/SearchUsersView.tsx
+++ b/src/pages/SearchPage/Views/SearchUsersView.tsx
@@ -23,6 +23,15 @@ const SearchUsersView = ({
     return null;
   }
 
+  const handleKeyDown = (
+    event: React.KeyboardEvent<HTMLElement>,
+    userId: string
+  ) => {
+    if (event.key === "Enter") {
+      onClick(userId);
+    }
+  };
+
   return (
     <>
       <ListWrap>
@@ -30,7 +39,9 @@ const SearchUsersView = ({
           usersData.map(user => (
             <ListItem
               key={user._id}
+              tabIndex={0}
               onClick={() => onClick(user._id)}
+              onKeyDown={event => handleKeyDown(event, user._id)}
               {...props}
             >
               <Avatar size="S" src={user.image} />

--- a/src/pages/SignInPage/SignInPageView.tsx
+++ b/src/pages/SignInPage/SignInPageView.tsx
@@ -126,6 +126,7 @@ const SignInPage = () => {
         </ErrorContainer>
         <InputContainer
           type="text"
+          aria-required="true"
           placeholder="looky@example.com"
           {...register("email", SignInPageConstant.EMAIL_VALIDATION_OPTION)}
         />
@@ -139,6 +140,7 @@ const SignInPage = () => {
         </ErrorContainer>
         <InputContainer
           type="text"
+          aria-required="true"
           placeholder="lookies"
           {...register(
             "fullName",
@@ -156,6 +158,7 @@ const SignInPage = () => {
         </ErrorContainer>
         <InputContainer
           type="password"
+          aria-required="true"
           placeholder="비밀번호"
           {...register(
             "password",
@@ -173,6 +176,7 @@ const SignInPage = () => {
         </ErrorContainer>
         <InputContainer
           type="password"
+          aria-required="true"
           placeholder="비밀번호 확인"
           {...register("passwordCheck", {
             ...SignInPageConstant.PASSWORD_CHECK_VALIDATION_OPTION,

--- a/src/pages/SignInPage/SignInPageView.tsx
+++ b/src/pages/SignInPage/SignInPageView.tsx
@@ -185,7 +185,10 @@ const SignInPage = () => {
           })}
         />
 
-        <SubmitButtonContainer onSubmit={handleSubmit(onValid, onInValid)}>
+        <SubmitButtonContainer
+          aria-label="회원가입을 위한 정보 제출 버튼"
+          onSubmit={handleSubmit(onValid, onInValid)}
+        >
           회원가입
         </SubmitButtonContainer>
       </FormContainer>


### PR DESCRIPTION
## 🔔 공지사항
- 프로필 페이지 커버 이미지 이벤트 할당 구조 변경
  - 기존 : Profile 커버 이미지가 존재하는 최상단 태그에 이벤트 바인딩
  - 변경 : Profile 태그 하단에 자식 형태의 버튼 태그로 이벤트 바인딩하여 다른 버튼과 동등한 조건 부여
- ButtonSet 페이지 구조 변경
  - 기존 : children을 받아 렌더링 하는 방식
  - 변경 : 배열 형태의 데이터를 받아 렌더링 하는 방식

## 📝작업 내용
- 대부분의 페이지에서의 웹 접근성 최적화
- 대부분의 페이지에서의 시맨틱 태그 적용
- 대부분의 페이지에서의 키보드 네비게이션 적용
- 접근 가능한 이름(Accessible Name) 추가

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
